### PR TITLE
Enable all the ruff rules we can without code changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ select = [
     "TID", # flake8-tidy-imports (TID)
     "ICN", # flake8-import-conventions (ICN)
     "Q", # flake8-quotes (Q)
+    "TC", # flake8-type-checking (TC)
 ]
 ignore = [
     "E501", # line-too-long (E501)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ select = [
     "E", # pycodestyle errors
     "F", # Pyflakes (F)
     "I", # isort (I)
+    "TID", # flake8-tidy-imports (TID)
 ]
 ignore = [
     "E501", # line-too-long (E501)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,13 @@ target-version = "py39"
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F", "I"]
-ignore = []
+select = [
+    "E4", "E7", "E9",  # subset of pycodestyle errors
+    "F", # Pyflakes (F)
+    "I", # isort (I)
+]
+ignore = [
+]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ select = [
     "F", # Pyflakes (F)
     "I", # isort (I)
     "TID", # flake8-tidy-imports (TID)
+    "ICN", # flake8-import-conventions (ICN)
 ]
 ignore = [
     "E501", # line-too-long (E501)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,12 @@ target-version = "py39"
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = [
-    "E4", "E7", "E9",  # subset of pycodestyle errors
+    "E", # pycodestyle errors
     "F", # Pyflakes (F)
     "I", # isort (I)
 ]
 ignore = [
+    "E501", # line-too-long (E501)
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ select = [
     "I", # isort (I)
     "TID", # flake8-tidy-imports (TID)
     "ICN", # flake8-import-conventions (ICN)
+    "Q", # flake8-quotes (Q)
 ]
 ignore = [
     "E501", # line-too-long (E501)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,0 @@
-import pytest
-
-# raise ValueError
-xfail_value_error = pytest.mark.xfail(raises=ValueError, strict=True)

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -11,7 +11,6 @@ import pytest
 from parsons import Table
 from parsons.utilities import check_env, files, json_format, sql_helpers
 from parsons.utilities.datetime import date_to_timestamp, parse_date
-from test.conftest import xfail_value_error
 
 
 @pytest.mark.parametrize(
@@ -20,7 +19,9 @@ from test.conftest import xfail_value_error
         pytest.param("2018-12-13", 1544659200),
         pytest.param("2018-12-13T00:00:00-08:00", 1544688000),
         pytest.param("", None),
-        pytest.param("2018-12-13 PST", None, marks=[xfail_value_error]),
+        pytest.param(
+            "2018-12-13 PST", None, marks=[pytest.mark.xfail(raises=ValueError, strict=True)]
+        ),
     ],
 )
 def test_date_to_timestamp(date, exp_ts):


### PR DESCRIPTION
- Remove and test/conftest.py as xfail_value_error is not needed
- Annotate the ruff rules listed in pyproject.toml
- Use full suite of [pycodestyle-error](https://docs.astral.sh/ruff/rules/#error-e) linting rules (except line length which is redundant to ruff format)
- Use [flake8-tidy-imports](https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid) linting rules
- Use [flake8-import-conventions](https://docs.astral.sh/ruff/rules/#flake8-import-conventions-icn) linting rules
- Use [flake8-quotes](https://docs.astral.sh/ruff/rules/#flake8-quotes-q) linting rules
- Use [flake8-type-checking](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc) linting rules